### PR TITLE
Support path for dialect-agnostic queries

### DIFF
--- a/src/main/java/it/openly/core/data/Query.java
+++ b/src/main/java/it/openly/core/data/Query.java
@@ -118,9 +118,10 @@ public class Query {
 
 	/**
 	 * Executes a statement.
+	 * @return A boolean
 	 */
-	public final void execute() {
-		execute(PreparedStatement::execute);
+	public final boolean execute() {
+		return execute(PreparedStatement::execute);
 	}
 
 	/**
@@ -128,9 +129,10 @@ public class Query {
 	 * {@link PreparedStatement#execute() PreparedStatement.execute} method.
 	 * @param preparedStatementCallback The callback
 	 * @param <T>
+	 * @return The execution's result
 	 */
-	public final <T> void execute(PreparedStatementCallback<T> preparedStatementCallback) {
-		namedParameterJdbcTemplate.execute(sqlStatement, context, preparedStatementCallback);
+	public final <T> T execute(PreparedStatementCallback<T> preparedStatementCallback) {
+		return namedParameterJdbcTemplate.execute(sqlStatement, context, preparedStatementCallback);
 	}
 
 	/**

--- a/src/main/java/it/openly/core/data/support/DefaultQueryResourceLoader.java
+++ b/src/main/java/it/openly/core/data/support/DefaultQueryResourceLoader.java
@@ -11,6 +11,7 @@ import javax.sql.DataSource;
 /**
  * This class allows loading queries from resources.
  * The path is composed based on a base path, combined with the database product as returned by the {@link DbProductDetector DbProductDetector} class.
+ * When there is no database-specific query, the class will combine the base path with the string "sql" and will try to load the query from there.
  *
  * @author filippo.possenti
  */
@@ -57,8 +58,10 @@ public class DefaultQueryResourceLoader implements IQueryResourceLoader {
     @Override
     public String loadQuery(@NonNull DataSource dataSource, @NonNull String namedQuery) {
         String detectedDbType = dbProductDetector.detectDbProduct(dataSource);
-        String namedQueryPath = FilenameUtils.concat(queriesBasePath, detectedDbType);
-        namedQueryPath = FilenameUtils.concat(namedQueryPath, namedQuery) + queryExtension;
+        String namedQueryPath = FilenameUtils.concat(FilenameUtils.concat(queriesBasePath, detectedDbType), namedQuery) + queryExtension;
+        if(!resourceResolver.hasResource(namedQueryPath)) {
+            namedQueryPath = FilenameUtils.concat(FilenameUtils.concat(queriesBasePath, "sql"), namedQuery) + queryExtension;
+        }
         return resourceResolver.resolveStringResource(namedQueryPath);
     }
 }

--- a/src/main/java/it/openly/core/resources/DefaultResourceResolver.java
+++ b/src/main/java/it/openly/core/resources/DefaultResourceResolver.java
@@ -4,6 +4,7 @@ import it.openly.core.exceptions.ResourceNotFoundException;
 import it.openly.core.exceptions.TooFewResultsException;
 import it.openly.core.exceptions.TooManyResultsException;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 import lombok.Getter;
@@ -31,6 +32,14 @@ public class DefaultResourceResolver implements IResourceResolver {
 	private Boolean failIfNotExisting = true;
 	private Boolean failIfManyExisting = true;
 
+	@SneakyThrows
+	public boolean hasResource(String resourceName) {
+		ResourcePatternResolver resolver = getResourcePatternResolver();
+		String path = composePath(resourceName);
+		Resource[] resources = resolver.getResources(path);
+		return resources.length > 0;
+	}
+
 	@Override
 	@SneakyThrows
 	public InputStream resolveResource(String resourceName) {
@@ -53,7 +62,7 @@ public class DefaultResourceResolver implements IResourceResolver {
 	public String resolveStringResource(String resourceName) {
 		return IOUtils.toString(resolveResource(resourceName));
 	}
-	
+
 	private String composePath(String resourceName) {
 		String result = getBasePath();
 		if (!StringUtils.endsWith(result, "/"))

--- a/src/main/java/it/openly/core/resources/IResourceResolver.java
+++ b/src/main/java/it/openly/core/resources/IResourceResolver.java
@@ -3,6 +3,9 @@ package it.openly.core.resources;
 import java.io.InputStream;
 
 public interface IResourceResolver {
+
+	boolean hasResource(String resourceName);
+
 	/**
 	 * Resolves a resource for use by the application.
 	 * @param resourceName

--- a/src/test/java/it/openly/core/data/tests/DefaultQueryResourceLoaderTest.java
+++ b/src/test/java/it/openly/core/data/tests/DefaultQueryResourceLoaderTest.java
@@ -41,6 +41,7 @@ public class DefaultQueryResourceLoaderTest {
         DefaultQueryResourceLoader defaultQueryResourceLoader = new DefaultQueryResourceLoader(resourceResolver, dbProductDetector, basepath, "");
 
         when(dbProductDetector.detectDbProduct(eq(dataSource))).thenReturn(dbtype);
+        when(resourceResolver.hasResource(eq(FilenameUtils.concat(FilenameUtils.concat(basepath, dbtype), queryname)))).thenReturn(true);
         when(resourceResolver.resolveStringResource(eq(FilenameUtils.concat(FilenameUtils.concat(basepath, dbtype), queryname)))).thenReturn(expectedQueryText);
 
         // when
@@ -50,4 +51,27 @@ public class DefaultQueryResourceLoaderTest {
         assertThat(actual, equalTo(expectedQueryText));
 
     }
+
+    @Test
+    public void testLoadQueryDefaultResource() {
+        // given
+        String basepath = UUID.randomUUID().toString();
+        String dbtype = UUID.randomUUID().toString();
+        String queryname = UUID.randomUUID().toString();
+        String expectedQueryText = UUID.randomUUID().toString();
+
+        DefaultQueryResourceLoader defaultQueryResourceLoader = new DefaultQueryResourceLoader(resourceResolver, dbProductDetector, basepath, "");
+
+        when(dbProductDetector.detectDbProduct(eq(dataSource))).thenReturn(dbtype);
+        when(resourceResolver.hasResource(eq(FilenameUtils.concat(FilenameUtils.concat(basepath, dbtype), queryname)))).thenReturn(false);
+        when(resourceResolver.resolveStringResource(eq(FilenameUtils.concat(FilenameUtils.concat(basepath, "sql"), queryname)))).thenReturn(expectedQueryText);
+
+        // when
+        String actual = defaultQueryResourceLoader.loadQuery(dataSource, queryname);
+
+        // then
+        assertThat(actual, equalTo(expectedQueryText));
+
+    }
+
 }


### PR DESCRIPTION
- Add a fallback path when dialect-specific queries are not found
- Modify the return values for the "execute" methods to reflect
  the base ones