### PR TITLE
Remove extension from query processing

### DIFF
--- a/src/main/java/it/openly/core/data/support/DefaultQueryResourceLoader.java
+++ b/src/main/java/it/openly/core/data/support/DefaultQueryResourceLoader.java
@@ -20,20 +20,17 @@ public class DefaultQueryResourceLoader implements IQueryResourceLoader {
     private final IResourceResolver resourceResolver;
     private final DbProductDetector dbProductDetector;
     private final String queriesBasePath;
-    private final String queryExtension;
 
     /**
      * Creates an instance of the class, specifying all parameters that drive the resolution of the resource to be loaded.
      * @param resourceResolver The resource resolver that will be tasked with loading the resource.
      * @param dbProductDetector The {@link DbProductDetector DbProductDetector} in charge of detecting the database product for path composition.
      * @param queriesBasePath The base path to the queries.
-     * @param queryExtension The extension, if any (including the dot) for each query resource.
      */
-    public DefaultQueryResourceLoader(IResourceResolver resourceResolver, DbProductDetector dbProductDetector, String queriesBasePath, String queryExtension) {
+    public DefaultQueryResourceLoader(IResourceResolver resourceResolver, DbProductDetector dbProductDetector, String queriesBasePath) {
         this.resourceResolver = resourceResolver;
         this.dbProductDetector = dbProductDetector;
         this.queriesBasePath = queriesBasePath;
-        this.queryExtension = queryExtension;
     }
 
     /**
@@ -46,7 +43,7 @@ public class DefaultQueryResourceLoader implements IQueryResourceLoader {
      * </ul>
      */
     public DefaultQueryResourceLoader() {
-        this(new DefaultResourceResolver(), new DbProductDetector(), "queries", ".sql");
+        this(new DefaultResourceResolver(), new DbProductDetector(), "queries");
     }
 
     /**
@@ -58,9 +55,9 @@ public class DefaultQueryResourceLoader implements IQueryResourceLoader {
     @Override
     public String loadQuery(@NonNull DataSource dataSource, @NonNull String namedQuery) {
         String detectedDbType = dbProductDetector.detectDbProduct(dataSource);
-        String namedQueryPath = FilenameUtils.concat(FilenameUtils.concat(queriesBasePath, detectedDbType), namedQuery) + queryExtension;
+        String namedQueryPath = FilenameUtils.concat(FilenameUtils.concat(queriesBasePath, detectedDbType), namedQuery);
         if(!resourceResolver.hasResource(namedQueryPath)) {
-            namedQueryPath = FilenameUtils.concat(FilenameUtils.concat(queriesBasePath, "sql"), namedQuery) + queryExtension;
+            namedQueryPath = FilenameUtils.concat(FilenameUtils.concat(queriesBasePath, "sql"), namedQuery);
         }
         return resourceResolver.resolveStringResource(namedQueryPath);
     }

--- a/src/test/java/it/openly/core/data/tests/DefaultQueryResourceLoaderTest.java
+++ b/src/test/java/it/openly/core/data/tests/DefaultQueryResourceLoaderTest.java
@@ -38,7 +38,7 @@ public class DefaultQueryResourceLoaderTest {
         String queryname = UUID.randomUUID().toString();
         String expectedQueryText = UUID.randomUUID().toString();
 
-        DefaultQueryResourceLoader defaultQueryResourceLoader = new DefaultQueryResourceLoader(resourceResolver, dbProductDetector, basepath, "");
+        DefaultQueryResourceLoader defaultQueryResourceLoader = new DefaultQueryResourceLoader(resourceResolver, dbProductDetector, basepath);
 
         when(dbProductDetector.detectDbProduct(eq(dataSource))).thenReturn(dbtype);
         when(resourceResolver.hasResource(eq(FilenameUtils.concat(FilenameUtils.concat(basepath, dbtype), queryname)))).thenReturn(true);
@@ -60,7 +60,7 @@ public class DefaultQueryResourceLoaderTest {
         String queryname = UUID.randomUUID().toString();
         String expectedQueryText = UUID.randomUUID().toString();
 
-        DefaultQueryResourceLoader defaultQueryResourceLoader = new DefaultQueryResourceLoader(resourceResolver, dbProductDetector, basepath, "");
+        DefaultQueryResourceLoader defaultQueryResourceLoader = new DefaultQueryResourceLoader(resourceResolver, dbProductDetector, basepath);
 
         when(dbProductDetector.detectDbProduct(eq(dataSource))).thenReturn(dbtype);
         when(resourceResolver.hasResource(eq(FilenameUtils.concat(FilenameUtils.concat(basepath, dbtype), queryname)))).thenReturn(false);

--- a/src/test/java/it/openly/core/data/tests/QueryFactoryTest.java
+++ b/src/test/java/it/openly/core/data/tests/QueryFactoryTest.java
@@ -70,7 +70,7 @@ public class QueryFactoryTest {
         List<Map<String, Object>> expectedResults = people.stream().filter(m -> m.get("LAST_NAME").equals(lastName)).collect(Collectors.toList());
 
         // when
-        List<Map<String, Object>> actualResults = queryFactory.queryForList("list", map("LAST_NAME", lastName));
+        List<Map<String, Object>> actualResults = queryFactory.queryForList("list.sql", map("LAST_NAME", lastName));
 
         // then
         assertThat(actualResults.size(), is(expectedResults.size()));
@@ -88,7 +88,7 @@ public class QueryFactoryTest {
         List<Map<String, Object>> expectedResults = people.stream().filter(m -> m.get("LAST_NAME").equals(lastName)).collect(Collectors.toList());
 
         // when
-        List<CoolPerson> actualResults = queryFactory.queryForBeans("list", CoolPerson.class, map("LAST_NAME", lastName));
+        List<CoolPerson> actualResults = queryFactory.queryForBeans("list.sql", CoolPerson.class, map("LAST_NAME", lastName));
 
         // then
         assertThat(actualResults.size(), is(expectedResults.size()));
@@ -110,7 +110,7 @@ public class QueryFactoryTest {
         long expectedResults = people.stream().filter(m -> m.get("LAST_NAME").equals(lastName)).count();
 
         // when
-        long actualResults = (long)queryFactory.queryForInt("count", map("LAST_NAME", lastName));
+        long actualResults = (long)queryFactory.queryForInt("count.sql", map("LAST_NAME", lastName));
 
         // then
         assertThat(actualResults, is(expectedResults));
@@ -123,7 +123,7 @@ public class QueryFactoryTest {
         long expectedResults = people.stream().filter(m -> m.get("LAST_NAME").equals(lastName)).count();
 
         // when
-        long actualResults = queryFactory.queryForLong("count", map("LAST_NAME", lastName));
+        long actualResults = queryFactory.queryForLong("count.sql", map("LAST_NAME", lastName));
 
         // then
         assertThat(actualResults, is(expectedResults));
@@ -136,7 +136,7 @@ public class QueryFactoryTest {
         Map<String, Object> expectedPerson = people.stream().filter(m -> m.get("IDX").equals(idx)).findAny().orElseThrow(IllegalArgumentException::new);
 
         // when
-        Map<String, Object> actualPerson = queryFactory.queryForMap("get", map("IDX", idx));
+        Map<String, Object> actualPerson = queryFactory.queryForMap("get.sql", map("IDX", idx));
 
         // then
         assertThat(actualPerson.get("FIRST_NAME"), is(expectedPerson.get("FIRST_NAME")));
@@ -147,10 +147,10 @@ public class QueryFactoryTest {
     public void testQueryForBean() {
         // given
         int idx = 3;
-        Map<String, Object> expectedPerson = queryFactory.queryForMap("get", map("IDX", idx));
+        Map<String, Object> expectedPerson = queryFactory.queryForMap("get.sql", map("IDX", idx));
 
         // when
-       CoolPerson actualPerson = queryFactory.queryForBean("get", CoolPerson.class, map("IDX", idx));
+       CoolPerson actualPerson = queryFactory.queryForBean("get.sql", CoolPerson.class, map("IDX", idx));
 
         // then
         assertThat(actualPerson.getIdx(), is(expectedPerson.get("IDX")));
@@ -167,7 +167,7 @@ public class QueryFactoryTest {
         String expectedPersonName = (String)people.stream().filter(m -> m.get("IDX").equals(idx)).findAny().orElseThrow(IllegalArgumentException::new).get("FIRST_NAME");
 
         // when
-       String actualPersonName = queryFactory.queryForObject("getfield", String.class, map("IDX", idx));
+       String actualPersonName = queryFactory.queryForObject("getfield.sql", String.class, map("IDX", idx));
 
         // then
         assertThat(actualPersonName, is(expectedPersonName));
@@ -180,8 +180,8 @@ public class QueryFactoryTest {
         double rating = 123.4;
 
         // when
-        int affectedRows = queryFactory.update("update", map("IDX", idx, "RATING", rating));
-        Map<String, Object> actualValue = queryFactory.queryForMap("get", map("IDX", idx));
+        int affectedRows = queryFactory.update("update.sql", map("IDX", idx, "RATING", rating));
+        Map<String, Object> actualValue = queryFactory.queryForMap("get.sql", map("IDX", idx));
 
 
         // then
@@ -197,7 +197,7 @@ public class QueryFactoryTest {
 
         // when
         LongAdder adder = new LongAdder();
-        queryFactory.iterate("list", r-> adder.increment(), map("LAST_NAME", lastName));
+        queryFactory.iterate("list.sql", r-> adder.increment(), map("LAST_NAME", lastName));
 
         // then
         assertThat(adder.intValue(), is(expectedResults.size()));
@@ -211,7 +211,7 @@ public class QueryFactoryTest {
 
         // when
         List<CoolPerson> actualResults = new ArrayList<>();
-        queryFactory.iterate("list", CoolPerson.class, actualResults::add, map("LAST_NAME", lastName));
+        queryFactory.iterate("list.sql", CoolPerson.class, actualResults::add, map("LAST_NAME", lastName));
 
         // then
         assertThat(actualResults.size(), is(expectedResults.size()));
@@ -234,8 +234,8 @@ public class QueryFactoryTest {
         double rating = 123.4;
 
         // when
-        queryFactory.execute("update", map("IDX", idx, "RATING", rating));
-        Map<String, Object> actualValue = queryFactory.queryForMap("get", map("IDX", idx));
+        queryFactory.execute("update.sql", map("IDX", idx, "RATING", rating));
+        Map<String, Object> actualValue = queryFactory.queryForMap("get.sql", map("IDX", idx));
 
         // then
         assertThat(((Number)actualValue.get("RATING")).doubleValue(), is(rating));
@@ -248,8 +248,8 @@ public class QueryFactoryTest {
         double rating = 456.7;
 
         // when
-        queryFactory.execute("update", PreparedStatement::execute, map("IDX", idx, "RATING", rating));
-        Map<String, Object> actualValue = queryFactory.queryForMap("get", map("IDX", idx));
+        queryFactory.execute("update.sql", PreparedStatement::execute, map("IDX", idx, "RATING", rating));
+        Map<String, Object> actualValue = queryFactory.queryForMap("get.sql", map("IDX", idx));
 
         // then
         assertThat(((Number)actualValue.get("RATING")).doubleValue(), is(rating));

--- a/src/test/java/it/openly/core/data/tests/QueryTest.java
+++ b/src/test/java/it/openly/core/data/tests/QueryTest.java
@@ -216,16 +216,18 @@ public class QueryTest {
     public void testExecuteCallsJdbcTemplateWithCorrectArguments() {
         // given
         String sql = "select 1";
+        when(namedParameterJdbcTemplate.execute(anyString(), anyMap(), any())).thenReturn(true);
 
         // when
         Query query = new Query(namedParameterJdbcTemplate, sql, context);
-        query.execute();
+        boolean result = query.execute();
 
         // then
         ArgumentCaptor<String> arg1 = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Map<String, Object>> arg2 = ArgumentCaptor.forClass(Map.class);
         verify(namedParameterJdbcTemplate, times(1)).execute(arg1.capture(), arg2.capture(), any());
         assertThat(arg1.getValue(), equalTo(sql));
+        assertThat(result, is(true));
         checkContextParameters(arg2);
     }
 

--- a/src/test/java/it/openly/core/data/tests/TransactionTest.java
+++ b/src/test/java/it/openly/core/data/tests/TransactionTest.java
@@ -68,14 +68,14 @@ public class TransactionTest {
         // given
         int idx = 3;
         double rating = 123.4;
-        double expectedRating = ((Number)queryFactory.queryForMap("get", map("IDX", idx)).get("RATING")).doubleValue();
+        double expectedRating = ((Number)queryFactory.queryForMap("get.sql", map("IDX", idx)).get("RATING")).doubleValue();
 
         // when
         Transaction transaction = queryFactory.getTransaction();
-        int affectedRows = queryFactory.update("update", map("IDX", idx, "RATING", rating));
-        Map<String, Object> changedValue = queryFactory.queryForMap("get", map("IDX", idx));
+        int affectedRows = queryFactory.update("update.sql", map("IDX", idx, "RATING", rating));
+        Map<String, Object> changedValue = queryFactory.queryForMap("get.sql", map("IDX", idx));
         transaction.rollback();
-        Map<String, Object> actualValue = queryFactory.queryForMap("get", map("IDX", idx));
+        Map<String, Object> actualValue = queryFactory.queryForMap("get.sql", map("IDX", idx));
 
         // then
         assertThat(affectedRows, is(1));
@@ -91,9 +91,9 @@ public class TransactionTest {
 
         // when
         Transaction transaction = queryFactory.getTransaction();
-        int affectedRows = queryFactory.update("update", map("IDX", idx, "RATING", rating));
+        int affectedRows = queryFactory.update("update.sql", map("IDX", idx, "RATING", rating));
         transaction.commit();
-        Map<String, Object> actualValue = queryFactory.queryForMap("get", map("IDX", idx));
+        Map<String, Object> actualValue = queryFactory.queryForMap("get.sql", map("IDX", idx));
 
         // then
         assertThat(affectedRows, is(1));
@@ -105,13 +105,13 @@ public class TransactionTest {
         // given
         int idx = 3;
         double rating = 123.4;
-        double expectedRating = ((Number)queryFactory.queryForMap("get", map("IDX", idx)).get("RATING")).doubleValue();
+        double expectedRating = ((Number)queryFactory.queryForMap("get.sql", map("IDX", idx)).get("RATING")).doubleValue();
 
         // when
         Transaction transaction = queryFactory.getTransaction();
         transaction.setRollbackOnly();
-        int affectedRows = queryFactory.update("update", map("IDX", idx, "RATING", rating));
-        Map<String, Object> changedValue = queryFactory.queryForMap("get", map("IDX", idx));
+        int affectedRows = queryFactory.update("update.sql", map("IDX", idx, "RATING", rating));
+        Map<String, Object> changedValue = queryFactory.queryForMap("get.sql", map("IDX", idx));
         try {
             transaction.commit();
             fail("RollbackOnlyException was not thrown.");
@@ -119,7 +119,7 @@ public class TransactionTest {
         catch (RollbackOnlyException roe) {
             // empty on purpose
         }
-        Map<String, Object> actualValue = queryFactory.queryForMap("get", map("IDX", idx));
+        Map<String, Object> actualValue = queryFactory.queryForMap("get.sql", map("IDX", idx));
 
         // then
         assertThat(affectedRows, is(1));


### PR DESCRIPTION
This commit removes the automatic extension suffix in order to reduce the amount of code and make it easier for developers to find the associated file